### PR TITLE
Bump dep versions for containers and semigroupoids

### DIFF
--- a/defaultable-map.cabal
+++ b/defaultable-map.cabal
@@ -24,9 +24,9 @@ library
     exposed-modules:  Defaultable.Map
                     , Defaultable.Map.Generalized
     build-depends:    base >= 4.14.3.0 && < 5
-                    , containers < 0.7
+                    , containers < 0.8
                     , deepseq >= 1.4.0.0 && < 1.5
-                    , semigroupoids < 5.4
+                    , semigroupoids < 6.1
     hs-source-dirs:   src
     default-language: Haskell2010
     ghc-options:      -Wall


### PR DESCRIPTION
This bump should be safe, as:
- `containers` changes seem compatible:[^1]
  - `0.7` only changes `Data.Graph.SCC v`, which is not used in `defaultable-map`,
- `semigroupoids` changes seems compatible:[^2]
  - `6` drops support for GHC 7.10 (not supported by `defaultable-map` either), migrated `Foldable1` and `Bifoldable1` compatibly, and added `Generic1`-based functions compatibly,
  - `6.0.0.1` fixes dependency version of transformers for GHC 9.6,
  - `6.0.1` fixes a build error when compiling with `-f-contravariant`.

[^1]: https://github.com/haskell/containers/blob/master/containers/changelog.md 
[^2]: https://github.com/ekmett/semigroupoids/blob/master/CHANGELOG.markdown